### PR TITLE
Expose Clarification from API, add JudgementType and Judgement

### DIFF
--- a/apiTypes.go
+++ b/apiTypes.go
@@ -99,7 +99,7 @@ type (
 		StartContestTime ApiRelTime `json:"start_contest_time"`
 		EndTime          *ApiTime   `json:"end_time,omitempty"`
 		EndContestTime   ApiRelTime `json:"end_contest_time,omitempty"`
-		MaxRunTime       number     `json:"max_run_time,omitempty"`
+		MaxRunTime       float32    `json:"max_run_time,omitempty"`
 	}
 
 	Clarification struct {

--- a/apiTypes.go
+++ b/apiTypes.go
@@ -79,9 +79,27 @@ type (
 		Time        *ApiTime        `json:"time,omitempty"`
 		ContestTime ApiRelTime      `json:"contest_time,omitempty"`
 		TeamId      string          `json:"team_id,omitempty"`
-		ProblemId   string          `json:"problem_id"`
+		ProblemId   string          `json:"problem_id,omitempty"`
 		EntryPoint  string          `json:"entry_point,omitempty"`
 		Files       []FileReference `json:"files,omitempty"`
+	}
+
+	JudgementType struct {
+		Id      string `json:"id,omitempty"`
+		Name    string `json:"name"`
+		Penalty bool   `json:"penalty,omitempty"`
+		Solved  bool   `json:"solved"`
+	}
+
+	Judgement struct {
+		Id               string     `json:"id,omitempty"`
+		SubmissionId     string     `json:"submission_id"`
+		JudgementTypeId  string     `json:"judgement_type_id,omitempty"`
+		StartTime        *ApiTime   `json:"start_time"`
+		StartContestTime ApiRelTime `json:"start_contest_time"`
+		EndTime          *ApiTime   `json:"end_time,omitempty"`
+		EndContestTime   ApiRelTime `json:"end_contest_time,omitempty"`
+		MaxRunTime       number     `json:"max_run_time,omitempty"`
 	}
 
 	Clarification struct {
@@ -193,6 +211,63 @@ contest time: %v
   problem id: %v
  entry point: %v
 `, s.Id, s.LanguageId, s.Time, s.ContestTime, s.TeamId, s.ProblemId, s.EntryPoint)
+}
+
+// -- Judgement Type implementation
+
+func (jt JudgementType) FromJSON(data []byte) (ApiType, error) {
+	err := json.Unmarshal(data, &jt)
+	return jt, err
+}
+
+func (jt JudgementType) InContest() bool {
+	return true
+}
+
+func (jt JudgementType) Path() string {
+	return "judgement-types"
+}
+
+func (jt JudgementType) Generate() ApiType {
+	return JudgementType{}
+}
+
+func (jt JudgementType) String() string {
+	return fmt.Sprintf(`
+       id: %v
+     name: %v
+  penalty: %v
+   solved: %v
+`, jt.Id, jt.Name, jt.Penalty, jt.Solved)
+}
+
+// -- Judgement implementation
+
+func (j Judgement) FromJSON(data []byte) (ApiType, error) {
+	err := json.Unmarshal(data, &j)
+	return j, err
+}
+
+func (j Judgement) InContest() bool {
+	return true
+}
+
+func (j Judgement) Path() string {
+	return "judgements"
+}
+
+func (j Judgement) Generate() ApiType {
+	return Judgement{}
+}
+
+func (j Judgement) String() string {
+	return fmt.Sprintf(`
+                id: %v
+     submission id: %v
+ judgement type id: %v
+start contest time: %v
+  end contest time: %v
+`, j.Id, j.SubmissionId, j.JudgementTypeId, j.StartContestTime, j.EndContestTime)
 }
 
 // -- Clarification implementation

--- a/interactions.go
+++ b/interactions.go
@@ -149,6 +149,111 @@ func (i inter) LanguageById(languageId string) (l Language, err error) {
 	return
 }
 
+func (i inter) JudgementTypes() ([]JudgementType, error) {
+	obj, err := i.GetObjects(JudgementType{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve judgement types; %w", err)
+	}
+
+	// obj should be a slice of JudgementType, cast to it to slice of JudgementType
+	ret := make([]JudgementType, len(obj))
+	for k, v := range obj {
+		vv, ok := v.(JudgementType)
+		if !ok {
+			return ret, fmt.Errorf("unexpected type found, expected judgement type, got: %T", v)
+		}
+
+		ret[k] = vv
+	}
+
+	return ret, nil
+}
+
+func (i inter) JudgementTypeById(judgementTypeId string) (jt JudgementType, err error) {
+	obj, err := i.GetObject(jt, judgementTypeId)
+	if err != nil {
+		return jt, fmt.Errorf("could not retrieve judgement type; %w", err)
+	}
+
+	vv, ok := obj.(JudgementType)
+	if !ok {
+		return jt, fmt.Errorf("unexpected type found, expected judgement type, got: %T", obj)
+	}
+
+	jt = vv
+	return
+}
+
+func (i inter) Judgements() ([]Judgement, error) {
+	obj, err := i.GetObjects(Judgement{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve judgements; %w", err)
+	}
+
+	// obj should be a slice of Judgement, cast to it to slice of Judgement
+	ret := make([]Judgement, len(obj))
+	for k, v := range obj {
+		vv, ok := v.(Judgement)
+		if !ok {
+			return ret, fmt.Errorf("unexpected type found, expected judgement, got: %T", v)
+		}
+
+		ret[k] = vv
+	}
+
+	return ret, nil
+}
+
+func (i inter) JudgementById(judgementId string) (j Judgement, err error) {
+	obj, err := i.GetObject(j, judgementId)
+	if err != nil {
+		return j, fmt.Errorf("could not retrieve judgement; %w", err)
+	}
+
+	vv, ok := obj.(Judgement)
+	if !ok {
+		return j, fmt.Errorf("unexpected type found, expected judgement, got: %T", obj)
+	}
+
+	j = vv
+	return
+}
+
+func (i inter) Clarifications() ([]Clarification, error) {
+	obj, err := i.GetObjects(Clarification{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve clarifications; %w", err)
+	}
+
+	// obj should be a slice of Clarification, cast to it to slice of Clarification
+	ret := make([]Clarification, len(obj))
+	for k, v := range obj {
+		vv, ok := v.(Clarification)
+		if !ok {
+			return ret, fmt.Errorf("unexpected type found, expected clarification, got: %T", v)
+		}
+
+		ret[k] = vv
+	}
+
+	return ret, nil
+}
+
+func (i inter) ClarificationById(clarificationId string) (c Clarification, err error) {
+	obj, err := i.GetObject(c, clarificationId)
+	if err != nil {
+		return c, fmt.Errorf("could not retrieve clarification; %w", err)
+	}
+
+	vv, ok := obj.(Clarification)
+	if !ok {
+		return c, fmt.Errorf("unexpected type found, expected clarification, got: %T", obj)
+	}
+
+	c = vv
+	return
+}
+
 func (i inter) PostClarification(problemId, text string) (Identifier, error) {
 	return i.postToId(i.contestPath("clarifications"), Clarification{
 		ProblemId: problemId,

--- a/interactor.go
+++ b/interactor.go
@@ -21,8 +21,17 @@ type (
 		Problems() ([]Problem, error)
 		ProblemById(problemId string) (Problem, error)
 
+		JudgementTypes() ([]JudgementType, error)
+		JudgementTypeById(judgementTypeId string) (JudgementType, error)
+
 		Submissions() ([]Submission, error)
 		SubmissionById(submissionId string) (Submission, error)
+
+		Judgements() ([]Judgement, error)
+		JudgementById(judgementId string) (Judgement, error)
+
+		Clarifications() ([]Clarification, error)
+		ClarificationById(clarificationId string) (Clarification, error)
 
 		Languages() ([]Language, error)
 		LanguageById(languageId string) (Language, error)

--- a/interactor_test.go
+++ b/interactor_test.go
@@ -205,28 +205,28 @@ func TestSubmissionRetrieval(t *testing.T) {
 func TestJudgementRetrieval(t *testing.T) {
 	api := interactor(t)
 
-	var jtId string
+	var jId string
 	t.Run("all-judgements", func(t *testing.T) {
 		judgements, err := api.Judgements()
 		assert.Nil(t, err)
 		assert.NotNil(t, judgements)
 
-		for _, jt := range judgements {
-			if jt.Id != "" {
-				jtId = jt.Id
+		for _, j := range judgements {
+			if j.Id != "" {
+				jId = j.Id
 				return
 			}
 		}
 	})
 
 	t.Run("single-judgement", func(t *testing.T) {
-		if jtId == "" {
+		if jId == "" {
 			t.Skip("no judgement could be found, retrieving single judgement cannot be tested")
 		}
 
-		jt, err := api.JudgementById(jtId)
+		j, err := api.JudgementById(jId)
 		assert.Nil(t, err)
-		assert.EqualValues(t, jtId, jt.Id)
+		assert.EqualValues(t, jId, j.Id)
 	})
 }
 

--- a/interactor_test.go
+++ b/interactor_test.go
@@ -143,6 +143,34 @@ func TestProblemRetrieval(t *testing.T) {
 	})
 }
 
+func TestJudgementTypeRetrieval(t *testing.T) {
+	api := interactor(t)
+
+	var jtId string
+	t.Run("all-judgement-types", func(t *testing.T) {
+		judgementTypes, err := api.JudgementTypes()
+		assert.Nil(t, err)
+		assert.NotNil(t, judgementTypes)
+
+		for _, jt := range judgementTypes {
+			if jt.Id != "" {
+				jtId = jt.Id
+				return
+			}
+		}
+	})
+
+	t.Run("single-judgement-type", func(t *testing.T) {
+		if jtId == "" {
+			t.Skip("no judgement type could be found, retrieving single judgement type cannot be tested")
+		}
+
+		jt, err := api.JudgementTypeById(jtId)
+		assert.Nil(t, err)
+		assert.EqualValues(t, jtId, jt.Id)
+	})
+}
+
 func TestSubmissionRetrieval(t *testing.T) {
 	api := interactor(t)
 
@@ -204,6 +232,34 @@ func TestLanguageRetrieval(t *testing.T) {
 		language, err := api.LanguageById(languageId)
 		assert.Nil(t, err)
 		assert.EqualValues(t, languageId, language.Id)
+	})
+}
+
+func TestClarificationRetrieval(t *testing.T) {
+	api := interactor(t)
+
+	var clarificationId string
+	t.Run("all-clarifications", func(t *testing.T) {
+		clarifications, err := api.Clarifications()
+		assert.Nil(t, err)
+		assert.NotNil(t, clarifications)
+
+		for _, clarification := range clarifications {
+			if clarification.Id != "" {
+				clarificationId = clarification.Id
+				return
+			}
+		}
+	})
+
+	t.Run("single-clarification", func(t *testing.T) {
+		if clarificationId == "" {
+			t.Skip("no clarification could be found, retrieving single clarification cannot be tested")
+		}
+
+		clarification, err := api.ProblemById(clarificationId)
+		assert.Nil(t, err)
+		assert.EqualValues(t, clarificationId, clarification.Id)
 	})
 }
 

--- a/interactor_test.go
+++ b/interactor_test.go
@@ -202,6 +202,34 @@ func TestSubmissionRetrieval(t *testing.T) {
 	})
 }
 
+func TestJudgementRetrieval(t *testing.T) {
+	api := interactor(t)
+
+	var jtId string
+	t.Run("all-judgements", func(t *testing.T) {
+		judgements, err := api.Judgements()
+		assert.Nil(t, err)
+		assert.NotNil(t, judgements)
+
+		for _, jt := range judgements {
+			if jt.Id != "" {
+				jtId = jt.Id
+				return
+			}
+		}
+	})
+
+	t.Run("single-judgement", func(t *testing.T) {
+		if jtId == "" {
+			t.Skip("no judgement could be found, retrieving single judgement cannot be tested")
+		}
+
+		jt, err := api.JudgementById(jtId)
+		assert.Nil(t, err)
+		assert.EqualValues(t, jtId, jt.Id)
+	})
+}
+
 func TestLanguageRetrieval(t *testing.T) {
 	api := interactor(t)
 
@@ -257,7 +285,7 @@ func TestClarificationRetrieval(t *testing.T) {
 			t.Skip("no clarification could be found, retrieving single clarification cannot be tested")
 		}
 
-		clarification, err := api.ProblemById(clarificationId)
+		clarification, err := api.ClarificationById(clarificationId)
 		assert.Nil(t, err)
 		assert.EqualValues(t, clarificationId, clarification.Id)
 	})


### PR DESCRIPTION
Expose the existing clarification object from the API and add judgement type and judgement, which will be needed by the cli. Also fixed the clarification problem id so that it isn't sent when empty.