### PR TITLE
POST returning id

### DIFF
--- a/apiTypes.go
+++ b/apiTypes.go
@@ -403,6 +403,7 @@ func (c Clarification) Generate() ApiType {
 
 func (c Clarification) String() string {
 	return fmt.Sprintf(`
+           id: %v
  from team id: %v
    to team id: %v
   reply to id: %v
@@ -410,7 +411,7 @@ func (c Clarification) String() string {
          text: %v
          time: %v
  contest time: %v
-`, c.FromTeamId, c.ToTeamId, c.ReplyToId, c.ProblemId, c.Text, c.Time, c.ContestTime)
+`, c.Id, c.FromTeamId, c.ToTeamId, c.ReplyToId, c.ProblemId, c.Text, c.Time, c.ContestTime)
 }
 
 // -- Language implementation

--- a/interactions.go
+++ b/interactions.go
@@ -436,7 +436,7 @@ func (i inter) Submit(s Submittable) (ApiType, error) {
 }
 
 func (i inter) GetObject(interactor ApiType, id string) (ApiType, error) {
-	objs, err := i.retrieve(interactor, i.toPath(interactor)+id, true)
+	objs, err := i.retrieve(interactor, i.toPath(interactor)+"/"+id, true)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve; %w", err)
@@ -455,7 +455,7 @@ func (i inter) toPath(interactor ApiType) string {
 		base = "contests/" + i.contestId + "/"
 	}
 
-	return base + interactor.Path() + "/"
+	return base + interactor.Path()
 }
 
 func (i inter) GetObjects(interactor ApiType) ([]ApiType, error) {

--- a/interactor.go
+++ b/interactor.go
@@ -124,14 +124,6 @@ func (i *inter) ToContest(cid string) (ContestApi, error) {
 	return i, nil
 }
 
-func (i inter) contestPath(path string) string {
-	if i.contestId != "" {
-		return fmt.Sprintf("contests/%s/%s", i.contestId, path)
-	}
-
-	return path
-}
-
 func buildClient(username, password string, insecure bool) http.Client {
 	// Create a transport for (possibly) insecure communication and adding of basic-auth headers
 	transport := http.DefaultTransport.(*http.Transport)

--- a/interactor.go
+++ b/interactor.go
@@ -48,9 +48,9 @@ type (
 		GetObject(interactor ApiType, id string) (ApiType, error)
 		GetObjects(interactor ApiType) ([]ApiType, error)
 
-		Submit(submittable Submittable) (Identifier, error)
-		PostClarification(problemId, text string) (Identifier, error)
-		PostSubmission(problemId, languageId, entrypoint string, files LocalFileReference) (Identifier, error)
+		Submit(submittable Submittable) (ApiType, error)
+		PostClarification(problemId, text string) (Clarification, error)
+		PostSubmission(problemId, languageId, entrypoint string, files LocalFileReference) (Submission, error)
 
 		Scoreboard() (Scoreboard, error)
 		State() (State, error)


### PR DESCRIPTION
Fixed post commands to accept objects back instead of ids. Also fixed two minor things:
- Added missing id to Clarification String() output.
- Updated ContestById to match other methods and just grab the one contest instead of looping through the list.