### PR TITLE
JSON error response

### DIFF
--- a/apiTypes.go
+++ b/apiTypes.go
@@ -151,6 +151,11 @@ type (
 	}
 
 	Identifier string
+
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
 )
 
 // -- Contest implementation

--- a/interactions.go
+++ b/interactions.go
@@ -554,8 +554,14 @@ func responseToError(r *http.Response) error {
 	// Read the contents
 	bts, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return fmt.Errorf("API error encountered (%v), furthermore an error was encountered while reading the response: %w", statusErr, err)
+		return fmt.Errorf("API error (%v), could not read response body: %w", statusErr, err)
 	}
 
-	return fmt.Errorf("API error '%s' (%w)", bts, statusErr)
+	var e Error
+	err = json.Unmarshal(bts, &e)
+	if err != nil {
+		return fmt.Errorf("API error (%v), couldn't parse details: %w", statusErr, err)
+	}
+
+	return fmt.Errorf("%s (error code %d)", e.Message, e.Code)
 }


### PR DESCRIPTION
Turns error messages from:
   Error: ... API error '{"code":400,"message":"Clarification text is empty"}' (invalid statuscode received: 400)
to:
   Error: ... Clarification text is empty (error code 400)

We still need to improve the first part of the error message and error chaining, but at least now you see the actual error message sent back from the server.